### PR TITLE
Fixed unhandled error when instance user data is not available during ingest

### DIFF
--- a/lib/aws/ingestor.py
+++ b/lib/aws/ingestor.py
@@ -1112,6 +1112,7 @@ class EC2(Ingestor):
             except ClientError:
                 self.console.error(f"Couldn't get user data for {name} "
                                    "- it may no longer exist.")
+                return
 
             if 'UserData' in response.keys() and 'Value' in response['UserData'].keys():
                 userdata = b64decode(response['UserData']['Value'])

--- a/lib/aws/ingestor.py
+++ b/lib/aws/ingestor.py
@@ -1112,7 +1112,7 @@ class EC2(Ingestor):
             except ClientError:
                 self.console.error(f"Couldn't get user data for {name} "
                                    "- it may no longer exist.")
-                return
+                continue
 
             if 'UserData' in response.keys() and 'Value' in response['UserData'].keys():
                 userdata = b64decode(response['UserData']['Value'])


### PR DESCRIPTION
Update of instance user data may fail with the error message "Could'nt get user data for {name} - it may no longer exist".
However, the error is not handled correctly and an exception is thrown while trying to parse the not existing userdata.